### PR TITLE
feat($vssue): i18n add pt-BR support

### DIFF
--- a/packages/vssue/src/i18n/index.ts
+++ b/packages/vssue/src/i18n/index.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 import enUS from './lang/en-US'
 import zhCN from './lang/zh-CN'
+import ptBR from './lang/pt-BR'
 
 if (!Vue.prototype.hasOwnProperty('$i18n')) {
   Vue.use(VueI18n)
@@ -15,6 +16,8 @@ const i18n: VueI18n = new VueI18n({
     'en-US': enUS,
     'zh': zhCN,
     'zh-CN': zhCN,
+    'pt': ptBR,
+    'pt-BR': ptBR,
   },
 })
 

--- a/packages/vssue/src/i18n/lang/pt-BR.ts
+++ b/packages/vssue/src/i18n/lang/pt-BR.ts
@@ -1,0 +1,51 @@
+import VueI18n from 'vue-i18n'
+
+const messages: VueI18n.LocaleMessageObject = {
+  // auth
+  login: 'Entrar com {platform}',
+  logout: 'Sair',
+  currentUser: 'Usuário Atual',
+
+  // comment input
+  loading: 'Carregando',
+  submit: 'Enviar',
+  submitting: 'Enviando',
+  submitComment: 'Enviar Comentário',
+  cancel: 'Cancelar',
+  edit: 'Editar',
+  editMode: 'Modo de Edição',
+  delete: 'Apagar',
+  reply: 'Responder',
+
+  // reactions
+  heart: 'Heart',
+  like: 'Like',
+  unlike: 'Unlike',
+
+  // pagination
+  perPage: 'Comentários por página',
+  sort: 'Clique para alterar a ordenação',
+  page: 'Página',
+  prev: 'Página Anterior',
+  next: 'Próxima Página',
+
+  // hint
+  comments: 'Comentários | {count} Comentários',
+  loginToComment: 'Entre com uma conta {platform} para deixar um comentário',
+  placeholder: 'Deixe um comentário. Estilos com Markdown suportados. Ctrl + Enter para enviar.',
+  noLoginPlaceHolder: 'Entre para deixar um comentário. Estilos com Markdown suportados. ',
+
+  // status
+  initializing: 'Inicializando...',
+  loadingComments: 'Carregando comentários...',
+  failed: 'Falha ao carregar comentários',
+  requireLogin: 'Entrar para visualizar comentários',
+  noComments: 'Nenhum comentário. Deixe o primeiro comentário!',
+
+  // alerts
+  reactionGiven: `Já reagiu com '{reaction}'`,
+  deleteConfirm: 'Apagar este comentário?',
+  deleteFailed: 'Falha ao apagar comentário',
+}
+
+export default messages


### PR DESCRIPTION
Added i18n support for pt-BR language.

As discussed in https://github.com/meteorlxy/vssue/issues/18 and https://github.com/meteorlxy/vuepress-theme-meteorlxy/issues/8