### PR TITLE
fix($api-github): use title as a label to help identify issue (close #24)

### DIFF
--- a/packages/@vssue/api-github-v3/__tests__/index.spec.ts
+++ b/packages/@vssue/api-github-v3/__tests__/index.spec.ts
@@ -267,6 +267,14 @@ describe('methods', () => {
         expect(issue).toBe(null)
       })
     })
+
+    test('without issue id or title', async () => {
+      const issue = await API.getIssue({
+        accessToken: null,
+      })
+      expect(mock.history.get.length).toBe(0)
+      expect(issue).toBe(null)
+    })
   })
 
   test('postIssue', async () => {

--- a/packages/@vssue/api-github-v3/src/index.ts
+++ b/packages/@vssue/api-github-v3/src/index.ts
@@ -236,9 +236,11 @@ export default class GithubV3 implements VssueAPI.Instance {
           throw e
         }
       }
-    } else {
+    }
+
+    if (issueTitle) {
       options.params = {
-        labels: this.labels.join(','),
+        labels: this.labels.concat(issueTitle).join(','),
         sort: 'created',
         direction: 'asc',
         state: 'all',
@@ -249,6 +251,8 @@ export default class GithubV3 implements VssueAPI.Instance {
       const issue = data.map(normalizeIssue).find(item => item.title === issueTitle)
       return issue || null
     }
+
+    return null
   }
 
   /**
@@ -274,7 +278,7 @@ export default class GithubV3 implements VssueAPI.Instance {
     const { data } = await this.$http.post(`repos/${this.owner}/${this.repo}/issues`, {
       title,
       body: content,
-      labels: this.labels,
+      labels: this.labels.concat(title),
     }, {
       headers: { 'Authorization': `token ${accessToken}` },
     })

--- a/packages/@vssue/api-github-v4/src/index.ts
+++ b/packages/@vssue/api-github-v4/src/index.ts
@@ -57,7 +57,7 @@ export default class GithubV4 implements VssueAPI.Instance {
     proxy,
   }: VssueAPI.Options) {
     if (typeof clientSecret === 'undefined' || typeof proxy === 'undefined') {
-      throw new Error('clientSecret and proxy is required for GitHub V3')
+      throw new Error('clientSecret and proxy is required for GitHub V4')
     }
     this.baseURL = baseURL
     this.owner = owner
@@ -278,12 +278,14 @@ query getIssueById {
           throw e
         }
       }
-    } else {
+    }
+
+    if (issueTitle) {
       const { data } = await this.$http.post(`graphql`, {
         variables: {
           owner: this.owner,
           repo: this.repo,
-          labels: this.labels,
+          labels: this.labels.concat(issueTitle),
         },
         query: `\
 query getIssueByTitle(
@@ -314,6 +316,8 @@ query getIssueByTitle(
       const issue = data.data.repository.issues.nodes.map(normalizeIssue).find(item => item.title === issueTitle)
       return issue || null
     }
+
+    return null
   }
 
   /**
@@ -346,7 +350,7 @@ query getIssueByTitle(
     const { data } = await this.$http.post(`repos/${this.owner}/${this.repo}/issues`, {
       title,
       body: content,
-      labels: this.labels,
+      labels: this.labels.concat(title),
     }, {
       headers: { 'Authorization': `token ${accessToken}` },
     })


### PR DESCRIPTION
Breaking changes:

- GitHub users have to regenerate the issues in existing projects, or add corresponding labels manually