### PR TITLE
fix(vuepress-plugin-vssue): add platform gitea and api

### DIFF
--- a/packages/@vssue/vuepress-plugin-vssue/src/index.ts
+++ b/packages/@vssue/vuepress-plugin-vssue/src/index.ts
@@ -10,6 +10,7 @@ module.exports = ({ platform = 'github', ...options }): Plugin => {
     gitlab: '@vssue/api-gitlab-v4',
     bitbucket: '@vssue/api-bitbucket-v2',
     gitee: '@vssue/api-gitee-v5',
+    gitea: '@vssue/api-gitea-v1'
   };
 
   const apiPkg = platformAPI[platform];


### PR DESCRIPTION
Gitea and its corresponding API are not added in index.js, resulting in errors during compilation.
![image](https://user-images.githubusercontent.com/39904328/140020587-0d7894a7-c234-436d-8452-97e8a8a3d7b1.png)
#7 